### PR TITLE
Update translateConst_en.js

### DIFF
--- a/app/app_components/translateModule/services/translateConst_en.js
+++ b/app/app_components/translateModule/services/translateConst_en.js
@@ -37,7 +37,7 @@ angular.module('translateModule')
         },
         dashboard: {
             headline: {
-                openRequest: 'Open PR\'s'
+                openRequest: 'Open PRs'
             },
             filter: {
                 byOldest: 'filter by time oldest first',


### PR DESCRIPTION
removed single quotation mark, 'cause: don't use it this way :)
